### PR TITLE
fix(imagemaid): bump base image from Buster to Bookworm

### DIFF
--- a/apps/imagemaid/Dockerfile
+++ b/apps/imagemaid/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk upgrade && \
 
 RUN git clone -b $VERSION  https://github.com/Kometa-Team/ImageMaid.git /source
 
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME ${BRANCH_NAME}
 ENV TINI_VERSION v0.19.0


### PR DESCRIPTION
## Summary

Debian Buster reached end-of-life in **June 2022**. The `deb.debian.org/debian buster` repository URLs now return HTTP 404, causing `apt-get update` to fail and breaking the CI build for this image.

This PR upgrades the base image from `python:3.11-slim-buster` to `python:3.11-slim-bookworm` (current Debian stable). All packages installed in the `RUN` layer (`gcc`, `g++`, `libxml2-dev`, `libxslt-dev`, `libz-dev`, `libjpeg62-turbo-dev`, `zlib1g-dev`, `wget`, `curl`, `tzdata`, `tmux`, `dialog`) are available in Bookworm with no further changes required.

No other modifications are made.