### PR TITLE
fix(postiz): add --experimental-require-module to fix ESM/CJS build error

### DIFF
--- a/apps/postiz/Dockerfile
+++ b/apps/postiz/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=cloner /source/. /app
 COPY --from=cloner /source/var/docker/nginx.conf /etc/nginx/nginx.conf
 
 RUN pnpm install
-RUN NODE_OPTIONS="--max-old-space-size=4096" pnpm run build
+RUN NODE_OPTIONS="--max-old-space-size=4096 --experimental-require-module" pnpm run build
 
 EXPOSE 4200
 


### PR DESCRIPTION
## Problem

The postiz Next.js build fails with `ERR_REQUIRE_ESM` during CI:

```
Error: Failed to load external module jsdom-...:
  Error [ERR_REQUIRE_ESM]: require() of ES Module .../node_modules/@exodus/bytes/encoding-lite.js
  from .../node_modules/isomorphic-dompurify/node_modules/html-encoding-sniffer/lib/html-encoding-sniffer.js
  not supported.
```

The dependency chain is:
- postiz uses `isomorphic-dompurify`
- `isomorphic-dompurify` depends on `jsdom`
- `jsdom` depends on `html-encoding-sniffer`
- `html-encoding-sniffer` depends on `@exodus/bytes` (which is ESM-only)
- During the Next.js build, `@exodus/bytes/encoding-lite.js` is `require()`d from a CommonJS context, which Node.js rejects with `ERR_REQUIRE_ESM`

## Fix

Add `--experimental-require-module` to `NODE_OPTIONS` during the build step. This flag (available as experimental in Node.js 20+, stable in Node.js 22+) allows `require()` to load synchronous ES modules, resolving the CJS/ESM interop issue without needing to alter `package.json` or pin dependency versions.

**Change:** `NODE_OPTIONS="--max-old-space-size=4096"` → `NODE_OPTIONS="--max-old-space-size=4096 --experimental-require-module"`

No other files are changed.