### PR TITLE
aioratings: add public catalog stub

### DIFF
--- a/apps/aioratings/ci/latest.sh
+++ b/apps/aioratings/ci/latest.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# AIORatings is the ElfHosted-internal Stremio ratings addon.
+# Source: https://github.com/elfhosted/aioratings (private)
+# Releases are cut by release-please from conventional commits on the
+# codex_ratings_port branch. Credentials come from ZURG_GH_CREDS,
+# already passed through action-image-build.yaml for cross-app use
+# (same pattern as elfbot/comet).
+
+set -euo pipefail
+
+channel="${1:-main}"
+repo="elfhosted/aioratings"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+case "$channel" in
+  dev)
+    version="$(
+      curl -fsSL \
+        -H "$auth_header" \
+        "https://api.github.com/repos/${repo}/commits/codex_ratings_port" \
+      | jq -r '.sha'
+    )"
+    ;;
+  *)
+    version="$(
+      curl -fsSL \
+        -H "$auth_header" \
+        "https://api.github.com/repos/${repo}/releases/latest" \
+      | jq -r '.tag_name'
+    )"
+    ;;
+esac
+
+printf '%s' "${version}"

--- a/apps/aioratings/metadata.json
+++ b/apps/aioratings/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "aioratings",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

AIORatings is the ElfHosted-internal Stremio ratings addon, source at https://github.com/elfhosted/aioratings (private). Releases are cut by release-please from conventional commits on the `codex_ratings_port` branch.

This adds the public catalog entry so `action-image-build` discovers the app:

- `apps/aioratings/metadata.json` — single stable `main` channel, `linux/amd64`, tests disabled (web app, no goss yet).
- `apps/aioratings/ci/latest.sh` — returns the latest GitHub Releases `tag_name` for the `main` channel; `codex_ratings_port` HEAD SHA for the `dev` channel. Auth via `ZURG_GH_CREDS` (same token elfbot uses for its private upstream).

The actual Dockerfile lives in [containers-private:feat/aioratings](https://github.com/elfhosted/containers-private/pulls?q=feat%2Faioratings) because the build clones the private source repo with credentials.

## Notes

- `latest.sh` will return `null` until the AIORatings repo's release-please workflow cuts its first release on the next push to `codex_ratings_port`. Once that lands and the GitHub release exists, `latest.sh main` will return `v2.0.0`.
- `dev` channel currently points at `codex_ratings_port`; if/when that branch is renamed to `main`, the `dev` case in `latest.sh` needs the same update.