### PR TITLE
chore(aioratings): track main branch (renamed from codex_ratings_port)

### DIFF
--- a/apps/aioratings/ci/latest.sh
+++ b/apps/aioratings/ci/latest.sh
@@ -2,7 +2,7 @@
 # AIORatings is the ElfHosted-internal Stremio ratings addon.
 # Source: https://github.com/elfhosted/aioratings (private)
 # Releases are cut by release-please from conventional commits on the
-# codex_ratings_port branch. Credentials come from ZURG_GH_CREDS,
+# main branch. Credentials come from ZURG_GH_CREDS,
 # already passed through action-image-build.yaml for cross-app use
 # (same pattern as elfbot/comet).
 
@@ -17,7 +17,7 @@ case "$channel" in
     version="$(
       curl -fsSL \
         -H "$auth_header" \
-        "https://api.github.com/repos/${repo}/commits/codex_ratings_port" \
+        "https://api.github.com/repos/${repo}/commits/main" \
       | jq -r '.sha'
     )"
     ;;


### PR DESCRIPTION
elfhosted/aioratings default branch was renamed codex_ratings_port → main. The dev-channel SHA query in `latest.sh` now hits `/commits/main` and the header comment reflects the new branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)