### PR TITLE
ci(catbox): enable goss/web smoke tests at container-build time

### DIFF
--- a/apps/catbox/metadata.json
+++ b/apps/catbox/metadata.json
@@ -9,7 +9,7 @@
       ],
       "stable": true,
       "tests": {
-        "enabled": false,
+        "enabled": true,
         "type": "web"
       }
     }


### PR DESCRIPTION
Paired with elfhosted/containers-private#19 that adds the /config mkdir to the Dockerfile and brings goss.yaml up to date. Both need to land before the next catbox release.

## Why

0.65.0 catbox shipped with an unbalanced \`{{if}}/{{end}}\` in backfill.html, which crashed startup with \`template: backfill.html:167: unexpected EOF\`. \`go build\` + tests passed, the image was published, the binary panicked the moment a tenant tried to run it.

With \`tests.enabled=false\` on catbox, the container build pipeline had nothing checking the binary even starts.

## Change

Flip \`tests.enabled\` to true so the dgoss smoke test runs against the just-built image. The actual check (process + /health + /ui/settings) lives in the goss.yaml in containers-private.

## Test plan

- [ ] containers-private sister PR merged in lock-step
- [ ] First catbox release with both PRs in place: dgoss step in action-image-build.yaml runs and passes