### PR TITLE
feat: add postersplus

### DIFF
--- a/apps/postersplus/ci/latest.sh
+++ b/apps/postersplus/ci/latest.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Fetch the latest version identifier for the postersplus image.
+#
+# We track the elfhosted/PostersPlus fork (not UmbraProjects upstream)
+# because the fork holds our hosting-mode commits — env-var-gated
+# backends for Postgres/Redis/S3, multi-replica leader election, the
+# Prometheus /metrics endpoint, etc. Upstream gets these via PR; the
+# fork rebases on upstream periodically.
+#
+# Channel:
+#   main  →  latest commit on the fork's main branch (short SHA).
+#            The fork doesn't tag releases yet; once it does, this can
+#            switch to /releases/latest for a stable channel.
+channel=$1
+
+version=$(curl -sX GET "https://api.github.com/repos/elfhosted/PostersPlus/commits/main" \
+  --header "Authorization: Bearer ${TOKEN}" \
+  | jq --raw-output '.sha[0:7]')
+
+printf "%s" "${version}"

--- a/apps/postersplus/metadata.json
+++ b/apps/postersplus/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "postersplus",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
ElfHosted-hosted Stremio poster overlay / badging service.

Source: [elfhosted/PostersPlus](https://github.com/elfhosted/PostersPlus) — our fork of UmbraProjects/PostersPlus with hosting-mode opt-in backends:

- Postgres / Redis / S3 backends (env-var-gated; SQLite/local/in-process by default)
- Per-tenant rate limiting
- Leader-elected background jobs
- Multi-process Prometheus `/metrics`
- Split `/live` and `/ready` probes
- Multi-stage hardened image (479 MB)

One channel `main` tracking the fork's main branch commit sha. Dockerfile lives in [containers-private/apps/postersplus](https://github.com/elfhosted/containers-private).