### PR TITLE
feat(postersplus): add stable channel tracking GitHub releases

### DIFF
--- a/apps/postersplus/ci/latest.sh
+++ b/apps/postersplus/ci/latest.sh
@@ -8,10 +8,12 @@
 # threads this through for cross-app use (same pattern as aioratings,
 # comet, elfbot). The default TOKEN doesn't have access to private repos.
 #
-# Channel:
-#   main  →  full sha of the latest commit on the fork's main branch.
-#            The fork doesn't tag releases yet; once it does, this can
-#            switch to /releases/latest for a stable channel.
+# Channels:
+#   main    →  full sha of the latest commit on the fork's main branch.
+#              Tracks rolling. HelmReleases shouldn't pin to this.
+#   stable  →  tag_name of the latest release-please-cut GitHub Release
+#              (e.g. v0.1.0). Stable image tag suitable for HelmRelease
+#              pinning.
 
 set -euo pipefail
 
@@ -19,11 +21,23 @@ channel="${1:-main}"
 repo="elfhosted/PostersPlus"
 auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
 
-version="$(
-  curl -fsSL \
-    -H "$auth_header" \
-    "https://api.github.com/repos/${repo}/commits/main" \
-  | jq -r '.sha'
-)"
+case "$channel" in
+  stable)
+    version="$(
+      curl -fsSL \
+        -H "$auth_header" \
+        "https://api.github.com/repos/${repo}/releases/latest" \
+      | jq -r '.tag_name'
+    )"
+    ;;
+  *)
+    version="$(
+      curl -fsSL \
+        -H "$auth_header" \
+        "https://api.github.com/repos/${repo}/commits/main" \
+      | jq -r '.sha'
+    )"
+    ;;
+esac
 
 printf '%s' "${version}"

--- a/apps/postersplus/metadata.json
+++ b/apps/postersplus/metadata.json
@@ -7,6 +7,17 @@
       "platforms": [
         "linux/amd64"
       ],
+      "stable": false,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    },
+    {
+      "name": "stable",
+      "platforms": [
+        "linux/amd64"
+      ],
       "stable": true,
       "tests": {
         "enabled": true,


### PR DESCRIPTION
Adds a `stable` channel for postersplus that pulls the latest GitHub release tag (e.g. `v0.1.0`) so HelmReleases can pin to immutable tags instead of rolling main-branch shas.

- `main` channel: tracks commit sha on main (rolling)
- `stable` channel: tracks tag name of latest release (pinnable)

Built image tags follow the channel: `ghcr.io/elfhosted/postersplus:v0.1.0` for stable, `:rolling` for main.