### PR TITLE
feat(shadowfax): public build entry

### DIFF
--- a/apps/shadowfax/ci/latest.sh
+++ b/apps/shadowfax/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# elfhosted/shadowfax is private — auth via ZURG_GH_CREDS.
+version=$(curl -sX GET https://api.github.com/repos/elfhosted/shadowfax/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.tag_name // empty')
+printf "%s" "${version}"

--- a/apps/shadowfax/metadata.json
+++ b/apps/shadowfax/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "shadowfax",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `apps/shadowfax` (metadata + `ci/latest.sh`). Inert until the first `elfhosted/shadowfax` release exists (latest.sh returns empty → no build). Dockerfile is in containers-private#feat/shadowfax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)