### PR TITLE
docs-internal image build def (+ bookseerr/sportarr wip)

### DIFF
--- a/apps/bookseerr/ci/latest.sh
+++ b/apps/bookseerr/ci/latest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# BookSeerr is hosted on a self-hosted GitLab instance with no releases or tags,
+# so we track the short commit SHA of the main branch. Project id 53 is stable
+# (resolved from /api/v4/projects/marco%2Fbookseerr). The GitLab API is public
+# and needs no auth for read access.
+version=$(curl -sX GET "https://gitlab.bertorello.info/api/v4/projects/53/repository/commits/main" | jq --raw-output '.short_id')
+printf "%s" "${version}"

--- a/apps/bookseerr/metadata.json
+++ b/apps/bookseerr/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "bookseerr",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/docs-internal/ci/latest.sh
+++ b/apps/docs-internal/ci/latest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# docs-internal builds from the (private) docs.elfhosted.com repo's main branch.
+# Use the latest main commit sha as the version, so a docs change triggers a
+# rebuild on the next scheduled run. ZURG_GH_CREDS must have read access to the
+# private docs repo.
+version=$(curl -sX GET "https://api.github.com/repos/elfhosted/docs.elfhosted.com/commits/main" --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.sha[0:7]')
+printf "%s" "${version}"

--- a/apps/docs-internal/metadata.json
+++ b/apps/docs-internal/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "docs-internal",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/shadowfax/ci/latest.sh
+++ b/apps/shadowfax/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# elfhosted/shadowfax is private — auth via ZURG_GH_CREDS.
+version=$(curl -sX GET https://api.github.com/repos/elfhosted/shadowfax/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.tag_name // empty')
+printf "%s" "${version}"

--- a/apps/shadowfax/metadata.json
+++ b/apps/shadowfax/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "shadowfax",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/sportarr/ci/latest.sh
+++ b/apps/sportarr/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/Sportarr/Sportarr/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#v}"
+printf "%s" "${version}"

--- a/apps/sportarr/metadata.json
+++ b/apps/sportarr/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "sportarr",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds docs-internal app build metadata (latest.sh tracks docs.elfhosted.com main sha; Dockerfile+goss in containers-private). Also bundles WIP bookseerr/sportarr app metadata. Triggers the docs-internal image build.