### PR TITLE
feat(m3ueditor): add m3u editor container

### DIFF
--- a/apps/m3ueditor/ci/latest.sh
+++ b/apps/m3ueditor/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/m3ue/m3u-editor/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/m3ueditor/metadata.json
+++ b/apps/m3ueditor/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "m3ueditor",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds the public container definition for **m3u editor** (EEP-123) — an IPTV playlist / EPG / Xtream Codes manager (upstream `m3ue/m3u-editor`, PHP/Laravel).

- `apps/m3ueditor/metadata.json` — single stable `main` channel, `linux/amd64`. Web tests **disabled**: the app needs external PostgreSQL + Redis (helm sidecars) to reach 200 on `/up`, so standalone goss can't pass.
- `apps/m3ueditor/ci/latest.sh` — tracks upstream GitHub `releases/latest` (strips `v` prefix).

The `Dockerfile` + `goss.yaml` live in `containers-private` (separate PR), as per convention.

## Licence note

Upstream is **CC BY-NC-SA 4.0** (NonCommercial). Hosting permission for ElfHosted was confirmed directly with the upstream developer.

## Verified

Image builds clean and the full modular stack (app + postgres + redis sidecars) boots healthy locally; `/up` → 200. Current upstream release at time of writing: v0.11.52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)