### PR TITLE
fix(ci): skip rebuild when upstream version lookup fails

### DIFF
--- a/.github/scripts/fetch.sh
+++ b/.github/scripts/fetch.sh
@@ -24,7 +24,12 @@ while read -r metadata; do
         upstream_version="${upstream_version//+/-}"
 
         latest_records+=("$(jo app="${app}" channel="${channel}" stable="${stable}" publishedVersion="${published_version}")")
-        if [[ "${published_version}" != "${upstream_version}" ]]; then
+        # An empty/null upstream version means the lookup failed (timeout, rate-limit,
+        # API error), not that a new version exists. Rebuilding anyway re-pushes the
+        # same tag with a new digest, churning renovate PRs and tenant clusters.
+        if [[ -z "${upstream_version}" || "${upstream_version}" == "null" ]]; then
+            echo "${app}$([[ ! ${stable} == false ]] || echo "-${channel}"): upstream version lookup failed, skipping" >&2
+        elif [[ "${published_version}" != "${upstream_version}" ]]; then
             echo "${app}$([[ ! ${stable} == false ]] || echo "-${channel}"):${published_version:-<NOTFOUND>} -> ${upstream_version}"
             changes_array+=("$(jo app="${app}" channel="${channel}")")
         fi


### PR DESCRIPTION
## Problem

The hourly `Release: Schedule` workflow rebuilds and re-pushes images whose version hasn't changed, whenever the upstream version lookup fails. `fetch.sh` does a bare string compare, so a `latest.sh` that times out (plex.tv, registry.hub.docker.com have been timing out from GH runners — see run [27223225154](https://github.com/elfhosted/containers/actions/runs/27223225154)) returns an empty string, which reads as "version changed":

```
curl: (28) Failed to connect to plex.tv port 443 after 300594 ms: Timeout was reached
plex:1.43.2.10687-563d026ea ->
```

The rebuild pushes the same tag with a new digest, which renovate dutifully turns into digest-bump PRs (e.g. elfhosted/myprecious#9624) and tenant cluster churn — every hour while the upstream endpoint is unreachable.

## Fix

Skip the rebuild check when the upstream version comes back empty or `null` (the latter from jq parsing a failed API response, e.g. `pageturner-dsc -> null` in the same run). A genuinely-unpublished app (`published=<NOTFOUND>`, upstream valid) still builds as before, and `latestVersions` output is unaffected.

Reviewed by codex-review: no correctness issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)